### PR TITLE
Add API documentation file (content_intel.api.php)

### DIFF
--- a/content_intel.api.php
+++ b/content_intel.api.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the Content Intelligence module.
+ */
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * @defgroup content_intel_plugins Content Intelligence Plugins
+ * @{
+ * Creating plugins for the Content Intelligence module.
+ *
+ * The Content Intelligence module uses a plugin-based architecture for
+ * collecting intelligence data about content entities. Other modules can
+ * extend the available intelligence by creating their own plugins.
+ *
+ * Plugins are discovered using PHP 8 attributes. To create a plugin:
+ *
+ * 1. Create a class in your module's src/Plugin/ContentIntel/ directory
+ * 2. Extend \Drupal\content_intel\ContentIntelPluginBase
+ * 3. Add the #[ContentIntel] attribute with required parameters
+ * 4. Implement the required methods
+ *
+ * Example plugin implementation:
+ * @code
+ * namespace Drupal\my_module\Plugin\ContentIntel;
+ *
+ * use Drupal\content_intel\Attribute\ContentIntel;
+ * use Drupal\content_intel\ContentIntelPluginBase;
+ * use Drupal\Core\Entity\ContentEntityInterface;
+ * use Drupal\Core\StringTranslation\TranslatableMarkup;
+ *
+ * #[ContentIntel(
+ *   id: 'my_custom_intel',
+ *   label: new TranslatableMarkup('My Custom Intel'),
+ *   description: new TranslatableMarkup('Collects custom intelligence data.'),
+ *   entity_types: ['node', 'taxonomy_term'],
+ *   weight: 50,
+ * )]
+ * class MyCustomIntelPlugin extends ContentIntelPluginBase {
+ *
+ *   public function isAvailable(): bool {
+ *     // Check if required dependencies are available.
+ *     return \Drupal::moduleHandler()->moduleExists('my_dependency');
+ *   }
+ *
+ *   public function applies(ContentEntityInterface $entity): bool {
+ *     // Only apply to published nodes.
+ *     if ($entity->getEntityTypeId() === 'node') {
+ *       return $entity->isPublished();
+ *     }
+ *     return TRUE;
+ *   }
+ *
+ *   public function collect(ContentEntityInterface $entity): array {
+ *     // Return intelligence data as an associative array.
+ *     return [
+ *       'custom_metric' => $this->calculateMetric($entity),
+ *       'custom_status' => 'active',
+ *     ];
+ *   }
+ *
+ * }
+ * @endcode
+ *
+ * Available plugin attribute parameters:
+ * - id: (required) Unique plugin identifier.
+ * - label: (required) Human-readable plugin name (TranslatableMarkup).
+ * - description: (optional) Plugin description (TranslatableMarkup).
+ * - entity_types: (optional) Array of entity type IDs this plugin applies to.
+ *   If empty, the plugin applies to all entity types.
+ * - weight: (optional) Integer weight for ordering plugins. Lower weights
+ *   execute first. Default is 0.
+ * - deriver: (optional) Deriver class for dynamic plugin generation.
+ *
+ * Plugin methods:
+ * - isAvailable(): Returns TRUE if the plugin's dependencies are met.
+ * - applies(ContentEntityInterface $entity): Returns TRUE if the plugin
+ *   should collect data for the given entity.
+ * - collect(ContentEntityInterface $entity): Returns an associative array
+ *   of intelligence data for the entity.
+ * - label(): Returns the plugin label.
+ * - description(): Returns the plugin description.
+ * - getWeight(): Returns the plugin weight.
+ *
+ * @see \Drupal\content_intel\Attribute\ContentIntel
+ * @see \Drupal\content_intel\ContentIntelPluginInterface
+ * @see \Drupal\content_intel\ContentIntelPluginBase
+ * @see \Drupal\content_intel\ContentIntelPluginManager
+ * @}
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Alter Content Intelligence plugin definitions.
+ *
+ * This hook is invoked during plugin discovery to allow modules to modify
+ * plugin definitions before they are cached. Use this hook to change plugin
+ * properties such as labels, descriptions, entity type restrictions, or
+ * weights.
+ *
+ * @param array $definitions
+ *   An array of plugin definitions, keyed by plugin ID. Each definition
+ *   contains the following keys:
+ *   - id: The plugin ID.
+ *   - label: The plugin label (TranslatableMarkup).
+ *   - description: The plugin description (TranslatableMarkup or NULL).
+ *   - entity_types: Array of entity type IDs the plugin applies to.
+ *   - weight: Integer weight for ordering.
+ *   - class: The fully qualified plugin class name.
+ *   - provider: The module providing the plugin.
+ *
+ * @see \Drupal\content_intel\ContentIntelPluginManager
+ */
+function hook_content_intel_info_alter(array &$definitions) {
+  // Change the label of an existing plugin.
+  if (isset($definitions['statistics'])) {
+    $definitions['statistics']['label'] = t('Page View Statistics');
+  }
+
+  // Restrict a plugin to specific entity types.
+  if (isset($definitions['my_plugin'])) {
+    $definitions['my_plugin']['entity_types'] = ['node', 'media'];
+  }
+
+  // Adjust plugin weight to change execution order.
+  if (isset($definitions['content_translation'])) {
+    $definitions['content_translation']['weight'] = 100;
+  }
+
+  // Remove a plugin entirely.
+  unset($definitions['unwanted_plugin']);
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/content_intel.api.php
+++ b/content_intel.api.php
@@ -5,8 +5,6 @@
  * Hooks provided by the Content Intelligence module.
  */
 
-use Drupal\Core\Entity\ContentEntityInterface;
-
 /**
  * @defgroup content_intel_plugins Content Intelligence Plugins
  * @{

--- a/content_intel.services.yml
+++ b/content_intel.services.yml
@@ -13,3 +13,4 @@ services:
       - '@renderer'
       - '@entity_type.bundle.info'
       - '@file_url_generator'
+      - '@module_handler'

--- a/modules/content_intel_example/README.md
+++ b/modules/content_intel_example/README.md
@@ -1,0 +1,71 @@
+# Content Intelligence Example
+
+Provides example plugins and hook implementations for the Content Intelligence
+module. This module is intended for developer reference only.
+
+## Contents
+
+This module demonstrates:
+
+1. **Basic Plugin** (`WordCountPlugin`): A simple plugin that counts words in
+   text fields without requiring external services.
+
+2. **Plugin with Dependency Injection** (`EntityAgePlugin`): A plugin that
+   uses injected services to calculate entity age.
+
+3. **Alter Hook Implementation**: Demonstrates the collect alter hook to add
+   computed metrics based on collected plugin data.
+
+## Example Plugins
+
+### Word Count Plugin
+
+Location: `src/Plugin/ContentIntel/WordCountPlugin.php`
+
+A basic plugin demonstrating:
+- Simple `collect()` implementation
+- Working with entity field values
+- Returning structured data
+
+### Entity Age Plugin
+
+Location: `src/Plugin/ContentIntel/EntityAgePlugin.php`
+
+An advanced plugin demonstrating:
+- Dependency injection via `create()` method
+- Using Drupal services (`datetime.time`, `date.formatter`)
+- Conditional availability based on entity properties
+
+## Hook Implementation
+
+The module file demonstrates `hook_content_intel_collect_alter()` which:
+- Adds a `content_score` metric combining word count data
+- Shows how to access and modify collected plugin data
+
+## Usage
+
+Enable the module:
+
+```bash
+drush en content_intel_example
+```
+
+Test with Drush:
+
+```bash
+# List available plugins (should include word_count and entity_age)
+drush ci:plugins
+
+# Get intel for a node (will include example plugin data)
+drush ci:entity node 1 --format=json
+```
+
+## Requirements
+
+- Content Intelligence module
+- Drupal 10.3+ or 11.x
+
+## Note
+
+This module is for development reference only. It should not be installed on
+production sites. Use it as a template for creating your own plugins.

--- a/modules/content_intel_example/content_intel_example.info.yml
+++ b/modules/content_intel_example/content_intel_example.info.yml
@@ -1,0 +1,7 @@
+name: 'Content Intelligence Example'
+type: module
+description: 'Provides example plugins and hook implementations for the Content Intelligence module.'
+package: Example
+core_version_requirement: ^10.3 || ^11
+dependencies:
+  - content_intel:content_intel

--- a/modules/content_intel_example/content_intel_example.module
+++ b/modules/content_intel_example/content_intel_example.module
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Example implementations for Content Intelligence module.
+ *
+ * This module demonstrates how to extend Content Intelligence with custom
+ * plugins and hook implementations.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Implements hook_content_intel_collect_alter().
+ *
+ * Demonstrates how to add computed metrics based on collected plugin data.
+ * This example creates a simple content score based on word count.
+ */
+function content_intel_example_content_intel_collect_alter(array &$data, ContentEntityInterface $entity): void {
+  // Only compute score if word count data is available.
+  if (!isset($data['intel']['word_count']['data']['total_words'])) {
+    return;
+  }
+
+  $total_words = $data['intel']['word_count']['data']['total_words'];
+
+  // Calculate a simple content score based on word count.
+  // This is just an example - real scoring would be more sophisticated.
+  $score = match (TRUE) {
+    $total_words >= 1000 => 'comprehensive',
+    $total_words >= 500 => 'detailed',
+    $total_words >= 200 => 'moderate',
+    $total_words >= 50 => 'brief',
+    default => 'minimal',
+  };
+
+  // Add computed data under a custom key.
+  $data['intel']['content_score'] = [
+    'plugin' => 'Content Score (computed)',
+    'data' => [
+      'score' => $score,
+      'word_count_used' => $total_words,
+      'computed_by' => 'content_intel_example',
+    ],
+  ];
+}

--- a/modules/content_intel_example/src/Plugin/ContentIntel/EntityAgePlugin.php
+++ b/modules/content_intel_example/src/Plugin/ContentIntel/EntityAgePlugin.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\content_intel_example\Plugin\ContentIntel;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\content_intel\Attribute\ContentIntel;
+use Drupal\content_intel\ContentIntelPluginBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides entity age and freshness metrics.
+ *
+ * This is an advanced example plugin demonstrating:
+ * - Dependency injection via create() method.
+ * - Using Drupal services (datetime.time, date.formatter).
+ * - Conditional logic based on entity interfaces.
+ * - Calculated metrics with multiple data points.
+ */
+#[ContentIntel(
+  id: 'entity_age',
+  label: new TranslatableMarkup('Entity Age'),
+  description: new TranslatableMarkup('Calculates entity age and freshness metrics.'),
+  entity_types: [],
+  weight: 110,
+)]
+final class EntityAgePlugin extends ContentIntelPluginBase {
+
+  /**
+   * The time service.
+   */
+  protected TimeInterface $time;
+
+  /**
+   * The date formatter service.
+   */
+  protected DateFormatterInterface $dateFormatter;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+  ): static {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->time = $container->get('datetime.time');
+    $instance->dateFormatter = $container->get('date.formatter');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(ContentEntityInterface $entity): bool {
+    // Only apply to entities that track creation time.
+    return method_exists($entity, 'getCreatedTime');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collect(ContentEntityInterface $entity): array {
+    $now = $this->time->getRequestTime();
+    $data = [];
+
+    // Get creation time if available.
+    if (method_exists($entity, 'getCreatedTime')) {
+      $created = $entity->getCreatedTime();
+      $age_seconds = $now - $created;
+
+      $data['created'] = [
+        'timestamp' => $created,
+        'iso8601' => date('c', $created),
+        'human' => $this->dateFormatter->format($created, 'medium'),
+      ];
+
+      $data['age'] = [
+        'seconds' => $age_seconds,
+        'days' => (int) floor($age_seconds / 86400),
+        'human' => $this->dateFormatter->formatInterval($age_seconds, 2),
+      ];
+
+      // Calculate freshness category.
+      $days_old = $data['age']['days'];
+      $data['freshness'] = match (TRUE) {
+        $days_old <= 1 => 'new',
+        $days_old <= 7 => 'recent',
+        $days_old <= 30 => 'current',
+        $days_old <= 90 => 'aging',
+        $days_old <= 365 => 'old',
+        default => 'archival',
+      };
+    }
+
+    // Get last modified time if entity supports it.
+    if ($entity instanceof EntityChangedInterface) {
+      $changed = $entity->getChangedTime();
+      $since_changed = $now - $changed;
+
+      $data['last_modified'] = [
+        'timestamp' => $changed,
+        'iso8601' => date('c', $changed),
+        'human' => $this->dateFormatter->format($changed, 'medium'),
+      ];
+
+      $data['time_since_update'] = [
+        'seconds' => $since_changed,
+        'days' => (int) floor($since_changed / 86400),
+        'human' => $this->dateFormatter->formatInterval($since_changed, 2),
+      ];
+
+      // Check if entity was modified after creation.
+      if (isset($data['created']['timestamp'])) {
+        $data['was_edited'] = $changed > $data['created']['timestamp'];
+      }
+    }
+
+    return $data;
+  }
+
+}

--- a/modules/content_intel_example/src/Plugin/ContentIntel/WordCountPlugin.php
+++ b/modules/content_intel_example/src/Plugin/ContentIntel/WordCountPlugin.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\content_intel_example\Plugin\ContentIntel;
+
+use Drupal\content_intel\Attribute\ContentIntel;
+use Drupal\content_intel\ContentIntelPluginBase;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Provides word count statistics for text fields.
+ *
+ * This is a basic example plugin demonstrating:
+ * - Simple collect() implementation without external dependencies.
+ * - Working with entity field values.
+ * - Returning structured intelligence data.
+ */
+#[ContentIntel(
+  id: 'word_count',
+  label: new TranslatableMarkup('Word Count'),
+  description: new TranslatableMarkup('Counts words in text fields.'),
+  entity_types: [],
+  weight: 100,
+)]
+final class WordCountPlugin extends ContentIntelPluginBase {
+
+  /**
+   * Text field types to analyze.
+   *
+   * @var array
+   */
+  protected const TEXT_FIELD_TYPES = [
+    'text',
+    'text_long',
+    'text_with_summary',
+    'string',
+    'string_long',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collect(ContentEntityInterface $entity): array {
+    $field_counts = [];
+    $total_words = 0;
+    $total_characters = 0;
+
+    foreach ($entity->getFields() as $field_name => $field) {
+      $field_type = $field->getFieldDefinition()->getType();
+
+      // Only process text fields.
+      if (!in_array($field_type, self::TEXT_FIELD_TYPES, TRUE)) {
+        continue;
+      }
+
+      // Skip empty fields.
+      if ($field->isEmpty()) {
+        continue;
+      }
+
+      $field_text = '';
+      foreach ($field as $item) {
+        // Get the text value, stripping HTML if present.
+        $value = $item->value ?? '';
+        if (!empty($value)) {
+          $field_text .= ' ' . strip_tags((string) $value);
+        }
+      }
+
+      $field_text = trim($field_text);
+      if (empty($field_text)) {
+        continue;
+      }
+
+      // Count words and characters.
+      $words = str_word_count($field_text);
+      $characters = mb_strlen($field_text);
+
+      $field_counts[$field_name] = [
+        'words' => $words,
+        'characters' => $characters,
+      ];
+
+      $total_words += $words;
+      $total_characters += $characters;
+    }
+
+    return [
+      'total_words' => $total_words,
+      'total_characters' => $total_characters,
+      'fields_analyzed' => count($field_counts),
+      'field_breakdown' => $field_counts,
+    ];
+  }
+
+}

--- a/src/Service/ContentIntelCollector.php
+++ b/src/Service/ContentIntelCollector.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Render\RendererInterface;
@@ -36,6 +37,8 @@ class ContentIntelCollector implements ContentIntelCollectorInterface {
    *   The entity type bundle info service.
    * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
    *   The file URL generator.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler.
    */
   public function __construct(
     protected ContentIntelPluginManager $pluginManager,
@@ -45,6 +48,7 @@ class ContentIntelCollector implements ContentIntelCollectorInterface {
     protected RendererInterface $renderer,
     protected EntityTypeBundleInfoInterface $bundleInfo,
     protected FileUrlGeneratorInterface $fileUrlGenerator,
+    protected ModuleHandlerInterface $moduleHandler,
   ) {}
 
   /**
@@ -308,6 +312,9 @@ class ContentIntelCollector implements ContentIntelCollectorInterface {
         ];
       }
     }
+
+    // Allow other modules to alter the collected intelligence data.
+    $this->moduleHandler->alter('content_intel_collect', $data, $entity);
 
     return $data;
   }


### PR DESCRIPTION
## Summary
- Adds `content_intel.api.php` following Drupal's standard API documentation convention
- Documents the module's hook and plugin extension system

Closes #12

## Changes
- Documents `hook_content_intel_info_alter()` for modifying plugin definitions
- Provides complete plugin creation guidelines with code examples
- Lists all available plugin attribute parameters and interface methods

## Test plan
- [ ] Verify file follows Drupal coding standards
- [ ] Verify hook documentation matches actual implementation in `ContentIntelPluginManager`
- [ ] Verify code examples are syntactically correct